### PR TITLE
feat(ui): improve spacing in create directory dialog

### DIFF
--- a/cms-lite-web-client/src/components/CreateDirectoryDialog.tsx
+++ b/cms-lite-web-client/src/components/CreateDirectoryDialog.tsx
@@ -22,6 +22,11 @@ const useStyles = makeStyles({
         flexDirection: 'column',
         gap: tokens.spacingVerticalM,
     },
+    inputGroup: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: tokens.spacingVerticalXS,
+    },
     pathHint: {
         color: tokens.colorNeutralForeground3,
     },
@@ -71,7 +76,7 @@ export const CreateDirectoryDialog = ({
                     <DialogTitle>Create new directory</DialogTitle>
                     <DialogContent>
                         <form className={styles.form} onSubmit={handleSubmit}>
-                            <div>
+                            <div className={styles.inputGroup}>
                                 <Label htmlFor="new-directory-name">Directory name</Label>
                                 <Input
                                     id="new-directory-name"
@@ -83,7 +88,7 @@ export const CreateDirectoryDialog = ({
                                 />
                             </div>
 
-                            <div>
+                            <div className={styles.inputGroup}>
                                 <Label>Location</Label>
                                 <Caption1 className={styles.pathHint}>{parentPath}</Caption1>
                             </div>


### PR DESCRIPTION
Adds vertical spacing between labels and inputs in the 'Create New Directory' modal to improve visual layout and readability.

- Introduces a new style `inputGroup` to manage spacing between form elements.
- Applies the new style to the directory name and location fields.
- Uses Fluent UI design tokens for consistent styling.