### PR TITLE
feat: Add /api prefix to all API endpoints

### DIFF
--- a/CmsLite/Authentication/AuthenticationEndpoints.cs
+++ b/CmsLite/Authentication/AuthenticationEndpoints.cs
@@ -2,12 +2,13 @@ using System.Security.Claims;
 using CmsLite.Database;
 using CmsLite.Database.Repositories;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Routing;
 
 namespace CmsLite.Authentication;
 
 public static class AuthenticationEndpoints
 {
-    public static void MapAuthenticationEndpoints(this WebApplication app)
+    public static void MapAuthenticationEndpoints(this IEndpointRouteBuilder app)
     {
         var authGroup = app.MapGroup("/auth").WithTags("Authentication");
         // POST /auth/login

--- a/CmsLite/Content/ContentEndpoints.cs
+++ b/CmsLite/Content/ContentEndpoints.cs
@@ -4,13 +4,14 @@ using CmsLite.Database.Repositories;
 using CmsLite.Helpers;
 using CmsLite.Helpers.RequestMappers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Routing;
 
 namespace CmsLite.Content;
 
 public static class ContentEndpoints
 {
 
-    public static void MapContentEndpoints(this WebApplication app)
+    public static void MapContentEndpoints(this IEndpointRouteBuilder app)
     {
         var contentGroup = app.MapGroup("/v1").WithTags("Content Management");
 

--- a/CmsLite/Content/DirectoryEndpoints.cs
+++ b/CmsLite/Content/DirectoryEndpoints.cs
@@ -3,12 +3,13 @@ using CmsLite.Database.Repositories;
 using CmsLite.Helpers;
 using CmsLite.Helpers.RequestMappers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Routing;
 
 namespace CmsLite.Content;
 
 public static class DirectoryEndpoints
 {
-    public static void MapDirectoryEndpoints(this WebApplication app)
+    public static void MapDirectoryEndpoints(this IEndpointRouteBuilder app)
     {
         var directoryGroup = app.MapGroup("/v1/{tenant}/directories").WithTags("Directory Management");
 

--- a/CmsLite/Program.cs
+++ b/CmsLite/Program.cs
@@ -215,8 +215,11 @@ else
 app.UseCmsLiteAuthentication();
 app.UseMiddleware<TenantValidationMiddleware>();
 app.UseRateLimiter();
-app.MapAuthenticationEndpoints();
-app.MapContentEndpoints();
-app.MapDirectoryEndpoints();
+
+var apiGroup = app.MapGroup("/api");
+apiGroup.MapAuthenticationEndpoints();
+apiGroup.MapContentEndpoints();
+apiGroup.MapDirectoryEndpoints();
+
 app.Run();
 public partial class Program { }

--- a/CmsLiteTests/BulkSoftDeleteApiTests.cs
+++ b/CmsLiteTests/BulkSoftDeleteApiTests.cs
@@ -23,7 +23,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
 
         // Create content first
         var contentData = JsonSerializer.Serialize(new { message = "Test content for deletion" });
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/test-resource.json",
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/test-resource.json",
             new StringContent(contentData, System.Text.Encoding.UTF8, "application/json"));
         Assert.True(putResponse.StatusCode == HttpStatusCode.OK || putResponse.StatusCode == HttpStatusCode.Created);
 
@@ -37,7 +37,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson, System.Text.Encoding.UTF8, "application/json")
         });
@@ -72,7 +72,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         foreach (var resource in resources)
         {
             var contentData = JsonSerializer.Serialize(new { name = resource, data = "test" });
-            var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/{resource}",
+            var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/{resource}",
                 new StringContent(contentData, System.Text.Encoding.UTF8, "application/json"));
             Assert.True(putResponse.StatusCode == HttpStatusCode.OK || putResponse.StatusCode == HttpStatusCode.Created);
         }
@@ -87,7 +87,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson, System.Text.Encoding.UTF8, "application/json")
         });
@@ -138,13 +138,13 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
 
         // Create content in root directory
         var contentData1 = JsonSerializer.Serialize(new { location = "root" });
-        var putResponse1 = await client.PutAsync($"/v1/{factory.TestTenant}/root-file.json",
+        var putResponse1 = await client.PutAsync($"/api/v1/{factory.TestTenant}/root-file.json",
             new StringContent(contentData1, System.Text.Encoding.UTF8, "application/json"));
         Assert.True(putResponse1.StatusCode == HttpStatusCode.OK || putResponse1.StatusCode == HttpStatusCode.Created);
 
         // Create content in subdirectory
         var contentData2 = JsonSerializer.Serialize(new { location = "subdirectory" });
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/v1/{factory.TestTenant}/sub-file.json")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/{factory.TestTenant}/sub-file.json")
         {
             Content = new StringContent(contentData2, System.Text.Encoding.UTF8, "application/json")
         };
@@ -163,7 +163,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson, System.Text.Encoding.UTF8, "application/json")
         });
@@ -199,7 +199,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson, System.Text.Encoding.UTF8, "application/json")
         });
@@ -236,7 +236,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson, System.Text.Encoding.UTF8, "application/json")
         });
@@ -264,7 +264,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
 
         // Create and then delete a resource
         var contentData = JsonSerializer.Serialize(new { message = "To be deleted twice" });
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/test-deleted.json",
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/test-deleted.json",
             new StringContent(contentData, System.Text.Encoding.UTF8, "application/json"));
         Assert.True(putResponse.StatusCode == HttpStatusCode.OK || putResponse.StatusCode == HttpStatusCode.Created);
 
@@ -277,7 +277,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        var deleteResponse1 = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+        var deleteResponse1 = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson1, System.Text.Encoding.UTF8, "application/json")
         });
@@ -292,7 +292,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        var deleteResponse2 = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+        var deleteResponse2 = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson2, System.Text.Encoding.UTF8, "application/json")
         });
@@ -325,7 +325,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson, System.Text.Encoding.UTF8, "application/json")
         });
@@ -343,7 +343,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
 
         // Create content
         var contentData = JsonSerializer.Serialize(new { message = "Test for duplicates" });
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/duplicate-test.json",
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/duplicate-test.json",
             new StringContent(contentData, System.Text.Encoding.UTF8, "application/json"));
         Assert.True(putResponse.StatusCode == HttpStatusCode.OK || putResponse.StatusCode == HttpStatusCode.Created);
 
@@ -357,7 +357,7 @@ public class BulkSoftDeleteApiTests : IAsyncDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+        var deleteResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson, System.Text.Encoding.UTF8, "application/json")
         });

--- a/CmsLiteTests/ContentApiDirectoryTests.cs
+++ b/CmsLiteTests/ContentApiDirectoryTests.cs
@@ -23,7 +23,7 @@ public class ContentApiDirectoryTests
         var payloadJson = JsonSerializer.Serialize(payload);
         var requestContent = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/test-content", requestContent);
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/test-content", requestContent);
         Assert.Equal(HttpStatusCode.Created, putResponse.StatusCode);
 
         using var scope = factory.Services.CreateScope();
@@ -70,7 +70,7 @@ public class ContentApiDirectoryTests
         var payloadJson = JsonSerializer.Serialize(payload);
         var requestContent = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/v1/{factory.TestTenant}/my-document")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/{factory.TestTenant}/my-document")
         {
             Content = requestContent
         };
@@ -97,7 +97,7 @@ public class ContentApiDirectoryTests
         var payloadJson = JsonSerializer.Serialize(payload);
         var requestContent = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/v1/{factory.TestTenant}/test-content")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/{factory.TestTenant}/test-content")
         {
             Content = requestContent
         };
@@ -150,7 +150,7 @@ public class ContentApiDirectoryTests
         var payloadJson = JsonSerializer.Serialize(payload);
         var requestContent = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/v1/{factory.TestTenant}/test-content")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/{factory.TestTenant}/test-content")
         {
             Content = requestContent
         };
@@ -192,7 +192,7 @@ public class ContentApiDirectoryTests
         var payloadJson = JsonSerializer.Serialize(payload);
         var requestContent = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/v1/{factory.TestTenant}/test-content")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/{factory.TestTenant}/test-content")
         {
             Content = requestContent
         };
@@ -216,7 +216,7 @@ public class ContentApiDirectoryTests
         var payloadJson = JsonSerializer.Serialize(payload);
         var requestContent = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
-        var putResponse = await client.PutAsync("/v1/non-existent-tenant/test-content", requestContent);
+        var putResponse = await client.PutAsync("/api/v1/non-existent-tenant/test-content", requestContent);
         Assert.Equal(HttpStatusCode.NotFound, putResponse.StatusCode);
     }
 
@@ -235,7 +235,7 @@ public class ContentApiDirectoryTests
         var requestContent = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
         // First, create content successfully to verify blob exists
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/test-content", requestContent);
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/test-content", requestContent);
         Assert.Equal(HttpStatusCode.Created, putResponse.StatusCode);
 
         // Verify blob was created (using new blob key format)

--- a/CmsLiteTests/ContentApiPdfTests.cs
+++ b/CmsLiteTests/ContentApiPdfTests.cs
@@ -36,7 +36,7 @@ public class ContentApiPdfTests : IAsyncDisposable
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
         var pdfBytes = CreateValidPdf("This is a test PDF document.");
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/test-document.pdf",
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/test-document.pdf",
             new ByteArrayContent(pdfBytes) { Headers = { ContentType = new("application/pdf") } });
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -56,7 +56,7 @@ public class ContentApiPdfTests : IAsyncDisposable
 
         // Create invalid PDF (doesn't start with %PDF-)
         var invalidPdfBytes = Encoding.UTF8.GetBytes("This is not a PDF file");
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/invalid-document.pdf",
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/invalid-document.pdf",
             new ByteArrayContent(invalidPdfBytes) { Headers = { ContentType = new("application/pdf") } });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -77,7 +77,7 @@ public class ContentApiPdfTests : IAsyncDisposable
         var content = new ByteArrayContent(pdfBytes);
         content.Headers.ContentType = null; // No Content-Type header
 
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/no-content-type.pdf", content);
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/no-content-type.pdf", content);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var responseContent = await response.Content.ReadAsStringAsync();
@@ -94,11 +94,11 @@ public class ContentApiPdfTests : IAsyncDisposable
 
         // Upload PDF first
         var pdfBytes = CreateValidPdf("Retrieve me!");
-        await client.PutAsync($"/v1/{factory.TestTenant}/retrieve-test.pdf",
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/retrieve-test.pdf",
             new ByteArrayContent(pdfBytes) { Headers = { ContentType = new("application/pdf") } });
 
         // Retrieve PDF
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/retrieve-test.pdf");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/retrieve-test.pdf");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
@@ -115,7 +115,7 @@ public class ContentApiPdfTests : IAsyncDisposable
         var token = factory.GenerateTestJwtToken();
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/nonexistent.pdf");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/nonexistent.pdf");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -130,11 +130,11 @@ public class ContentApiPdfTests : IAsyncDisposable
 
         // Upload PDF first
         var pdfBytes = CreateValidPdf("Metadata test");
-        await client.PutAsync($"/v1/{factory.TestTenant}/metadata-test.pdf",
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/metadata-test.pdf",
             new ByteArrayContent(pdfBytes) { Headers = { ContentType = new("application/pdf") } });
 
         // Get metadata with HEAD
-        var request = new HttpRequestMessage(HttpMethod.Head, $"/v1/{factory.TestTenant}/metadata-test.pdf");
+        var request = new HttpRequestMessage(HttpMethod.Head, $"/api/v1/{factory.TestTenant}/metadata-test.pdf");
         var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -161,24 +161,24 @@ public class ContentApiPdfTests : IAsyncDisposable
 
         // Upload version 1
         var pdfV1 = CreateValidPdf("Version 1 content");
-        var response1 = await client.PutAsync($"/v1/{factory.TestTenant}/versioned.pdf",
+        var response1 = await client.PutAsync($"/api/v1/{factory.TestTenant}/versioned.pdf",
             new ByteArrayContent(pdfV1) { Headers = { ContentType = new("application/pdf") } });
         Assert.Equal(HttpStatusCode.Created, response1.StatusCode);
 
         // Upload version 2
         var pdfV2 = CreateValidPdf("Version 2 content - updated");
-        var response2 = await client.PutAsync($"/v1/{factory.TestTenant}/versioned.pdf",
+        var response2 = await client.PutAsync($"/api/v1/{factory.TestTenant}/versioned.pdf",
             new ByteArrayContent(pdfV2) { Headers = { ContentType = new("application/pdf") } });
         Assert.True(response2.StatusCode == HttpStatusCode.OK || response2.StatusCode == HttpStatusCode.Created);
 
         // Get latest version (should be version 2)
-        var getResponse = await client.GetAsync($"/v1/{factory.TestTenant}/versioned.pdf");
+        var getResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/versioned.pdf");
         Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
         var retrievedBytes = await getResponse.Content.ReadAsByteArrayAsync();
         Assert.Equal(pdfV2, retrievedBytes);
 
         // Get version 1 explicitly
-        var getV1Response = await client.GetAsync($"/v1/{factory.TestTenant}/versioned.pdf?version=1");
+        var getV1Response = await client.GetAsync($"/api/v1/{factory.TestTenant}/versioned.pdf?version=1");
         Assert.Equal(HttpStatusCode.OK, getV1Response.StatusCode);
         var retrievedV1Bytes = await getV1Response.Content.ReadAsByteArrayAsync();
         Assert.Equal(pdfV1, retrievedV1Bytes);
@@ -194,15 +194,15 @@ public class ContentApiPdfTests : IAsyncDisposable
 
         // Upload PDF
         var pdfBytes = CreateValidPdf("Delete me");
-        await client.PutAsync($"/v1/{factory.TestTenant}/to-delete.pdf",
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/to-delete.pdf",
             new ByteArrayContent(pdfBytes) { Headers = { ContentType = new("application/pdf") } });
 
         // Delete PDF (soft delete)
-        var deleteResponse = await client.DeleteAsync($"/v1/{factory.TestTenant}/to-delete.pdf");
+        var deleteResponse = await client.DeleteAsync($"/api/v1/{factory.TestTenant}/to-delete.pdf");
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
         // Try to retrieve deleted PDF
-        var getResponse = await client.GetAsync($"/v1/{factory.TestTenant}/to-delete.pdf");
+        var getResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/to-delete.pdf");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
     }
 
@@ -216,11 +216,11 @@ public class ContentApiPdfTests : IAsyncDisposable
 
         // Upload a PDF
         var pdfBytes = CreateValidPdf("List test");
-        await client.PutAsync($"/v1/{factory.TestTenant}/list-test.pdf",
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/list-test.pdf",
             new ByteArrayContent(pdfBytes) { Headers = { ContentType = new("application/pdf") } });
 
         // List resources
-        var listResponse = await client.GetAsync($"/v1/{factory.TestTenant}");
+        var listResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}");
         Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
 
         var content = await listResponse.Content.ReadAsStringAsync();
@@ -238,7 +238,7 @@ public class ContentApiPdfTests : IAsyncDisposable
         var emptyContent = new ByteArrayContent(Array.Empty<byte>());
         emptyContent.Headers.ContentType = new("application/pdf");
 
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/empty.pdf", emptyContent);
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/empty.pdf", emptyContent);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var content = await response.Content.ReadAsStringAsync();
@@ -253,7 +253,7 @@ public class ContentApiPdfTests : IAsyncDisposable
         // No authentication token
 
         var pdfBytes = CreateValidPdf();
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/unauthorized.pdf",
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/unauthorized.pdf",
             new ByteArrayContent(pdfBytes) { Headers = { ContentType = new("application/pdf") } });
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -269,7 +269,7 @@ public class ContentApiPdfTests : IAsyncDisposable
 
         // Create corrupted PDF with valid header but invalid structure
         var corruptedPdf = Encoding.UTF8.GetBytes("%PDF-1.4\nCorrupted content without proper PDF structure");
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/corrupted.pdf",
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/corrupted.pdf",
             new ByteArrayContent(corruptedPdf) { Headers = { ContentType = new("application/pdf") } });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -289,7 +289,7 @@ public class ContentApiPdfTests : IAsyncDisposable
         var largePdfContent = new byte[8388609]; // 8 MB + 1 byte
         Array.Copy(Encoding.UTF8.GetBytes("%PDF-1.4"), largePdfContent, 8);
 
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/large.pdf",
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/large.pdf",
             new ByteArrayContent(largePdfContent) { Headers = { ContentType = new("application/pdf") } });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -309,7 +309,7 @@ public class ContentApiPdfTests : IAsyncDisposable
         var noPagesContent = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\nxref\n0 2\n0000000000 65535 f\n0000000009 00000 n\ntrailer\n<< /Size 2 /Root 1 0 R >>\nstartxref\n50\n%%EOF\n";
         var noPagesBytes = Encoding.UTF8.GetBytes(noPagesContent);
 
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/no-pages.pdf",
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/no-pages.pdf",
             new ByteArrayContent(noPagesBytes) { Headers = { ContentType = new("application/pdf") } });
 
         // This should fail validation - either "no pages" or structure error
@@ -329,7 +329,7 @@ public class ContentApiPdfTests : IAsyncDisposable
         // Use the helper method to create a valid minimal PDF
         var validPdf = CreateValidPdf("Minimal test content");
 
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/minimal-valid.pdf",
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/minimal-valid.pdf",
             new ByteArrayContent(validPdf) { Headers = { ContentType = new("application/pdf") } });
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);

--- a/CmsLiteTests/ContentApiSanitizationTests.cs
+++ b/CmsLiteTests/ContentApiSanitizationTests.cs
@@ -26,7 +26,7 @@ public class ContentApiSanitizationTests : IAsyncDisposable
         var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
         // Upload with spaces in name: "Clean Code.json"
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/Clean Code.json", content);
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/Clean Code.json", content);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var responseBody = await response.Content.ReadAsStringAsync();
@@ -48,7 +48,7 @@ public class ContentApiSanitizationTests : IAsyncDisposable
         var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
         // Upload with special characters: "Annual Report (Q4) 2024!.json"
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/Annual Report (Q4) 2024!.json", content);
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/Annual Report (Q4) 2024!.json", content);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var responseBody = await response.Content.ReadAsStringAsync();
@@ -69,10 +69,10 @@ public class ContentApiSanitizationTests : IAsyncDisposable
         var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
         // Upload with spaces
-        await client.PutAsync($"/v1/{factory.TestTenant}/My Document.json", content);
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/My Document.json", content);
 
         // Retrieve using sanitized name
-        var getResponse = await client.GetAsync($"/v1/{factory.TestTenant}/my-document.json");
+        var getResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/my-document.json");
         Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
 
         var retrievedContent = await getResponse.Content.ReadAsStringAsync();
@@ -92,7 +92,7 @@ public class ContentApiSanitizationTests : IAsyncDisposable
 
         // Note: This will try to use a different tenant name which may not exist
         // The test verifies sanitization happens even if tenant doesn't exist
-        var response = await client.PutAsync("/v1/ACME Corp!/test.json", content);
+        var response = await client.PutAsync("/api/v1/ACME Corp!/test.json", content);
 
         // Will fail with 404 because tenant doesn't exist, but URL was sanitized
         Assert.True(response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == HttpStatusCode.BadRequest);
@@ -110,7 +110,7 @@ public class ContentApiSanitizationTests : IAsyncDisposable
         var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
         // Upload with uppercase extension
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/MyFile.JSON", content);
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/MyFile.JSON", content);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var responseBody = await response.Content.ReadAsStringAsync();
@@ -131,7 +131,7 @@ public class ContentApiSanitizationTests : IAsyncDisposable
         var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
         // Upload with multiple consecutive spaces
-        var response = await client.PutAsync($"/v1/{factory.TestTenant}/My    Document    File.json", content);
+        var response = await client.PutAsync($"/api/v1/{factory.TestTenant}/My    Document    File.json", content);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var responseBody = await response.Content.ReadAsStringAsync();
@@ -152,11 +152,11 @@ public class ContentApiSanitizationTests : IAsyncDisposable
         var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
         // Upload multiple files with spaces
-        await client.PutAsync($"/v1/{factory.TestTenant}/File One.json", content);
-        await client.PutAsync($"/v1/{factory.TestTenant}/File Two.json", content);
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/File One.json", content);
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/File Two.json", content);
 
         // List resources
-        var listResponse = await client.GetAsync($"/v1/{factory.TestTenant}");
+        var listResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}");
         Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
 
         var listContent = await listResponse.Content.ReadAsStringAsync();

--- a/CmsLiteTests/ContentApiTests.cs
+++ b/CmsLiteTests/ContentApiTests.cs
@@ -25,7 +25,7 @@ public class ContentApiTests
         var byteLength = Encoding.UTF8.GetByteCount(payloadJson);
         var requestContent = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/home", requestContent);
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/home", requestContent);
         Assert.Equal(HttpStatusCode.Created, putResponse.StatusCode);
 
         var created = await putResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -39,7 +39,7 @@ public class ContentApiTests
         var sha = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payloadJson)));
         Assert.Equal(sha, created.GetProperty("sha256").GetString());
 
-        var getResponse = await client.GetAsync($"/v1/{factory.TestTenant}/home");
+        var getResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/home");
         Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
         Assert.Equal("application/json", getResponse.Content.Headers.ContentType?.MediaType);
         Assert.True(getResponse.Headers.TryGetValues("ETag", out var etagValues));
@@ -63,9 +63,9 @@ public class ContentApiTests
         await factory.InitializeAsync();
         var client = factory.CreateAuthenticatedClient();
 
-        await client.PutAsync($"/v1/{factory.TestTenant}/page-mismatch", CreateJsonContent(new { version = 1 }));
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/page-mismatch", CreateJsonContent(new { version = 1 }));
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/v1/{factory.TestTenant}/page-mismatch")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/{factory.TestTenant}/page-mismatch")
         {
             Content = CreateJsonContent(new { version = 2 })
         };
@@ -86,8 +86,8 @@ public class ContentApiTests
         using var factory = new CmsLiteTestFactoryAuth();
         await factory.InitializeAsync();
         var client = factory.CreateAuthenticatedClient();
-        await client.PutAsync($"/v1/{factory.TestTenant}/article", CreateJsonContent(new { title = "one" }));
-        var headRequest = new HttpRequestMessage(HttpMethod.Head, $"/v1/{factory.TestTenant}/article");
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/article", CreateJsonContent(new { title = "one" }));
+        var headRequest = new HttpRequestMessage(HttpMethod.Head, $"/api/v1/{factory.TestTenant}/article");
         var head = await client.SendAsync(headRequest);
         var content = await head.Content.ReadAsStringAsync();
         Assert.Equal(HttpStatusCode.OK, head.StatusCode);
@@ -105,11 +105,11 @@ public class ContentApiTests
         await factory.InitializeAsync();
         var client = factory.CreateAuthenticatedClient();
 
-        await client.PutAsync($"/v1/{factory.TestTenant}/home", CreateJsonContent(new { title = "home" }));
-        await client.PutAsync($"/v1/{factory.TestTenant}/help", CreateJsonContent(new { title = "help" }));
-        await client.PutAsync($"/v1/{factory.TestTenant}/blog", CreateJsonContent(new { title = "blog" }));
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/home", CreateJsonContent(new { title = "home" }));
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/help", CreateJsonContent(new { title = "help" }));
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/blog", CreateJsonContent(new { title = "blog" }));
 
-        var listResponse = await client.GetAsync($"/v1/{factory.TestTenant}?prefix=he");
+        var listResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}?prefix=he");
         Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
         var listJson = await listResponse.Content.ReadFromJsonAsync<JsonElement>();
         var items = listJson.GetProperty("items").EnumerateArray().ToArray();
@@ -125,15 +125,15 @@ public class ContentApiTests
         await factory.InitializeAsync();
         var client = factory.CreateAuthenticatedClient();
 
-        await client.PutAsync($"/v1/{factory.TestTenant}/home", CreateJsonContent(new { title = "home" }));
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/home", CreateJsonContent(new { title = "home" }));
 
-        var deleteResponse = await client.DeleteAsync($"/v1/{factory.TestTenant}/home");
+        var deleteResponse = await client.DeleteAsync($"/api/v1/{factory.TestTenant}/home");
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
-        var getResponse = await client.GetAsync($"/v1/{factory.TestTenant}/home");
+        var getResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/home");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
 
-        var includeDeleted = await client.GetAsync($"/v1/{factory.TestTenant}?includeDeleted=true");
+        var includeDeleted = await client.GetAsync($"/api/v1/{factory.TestTenant}?includeDeleted=true");
         Assert.Equal(HttpStatusCode.OK, includeDeleted.StatusCode);
         var payload = await includeDeleted.Content.ReadFromJsonAsync<JsonElement>();
         var deletedItems = payload.GetProperty("items").EnumerateArray().ToArray();
@@ -148,10 +148,10 @@ public class ContentApiTests
         await factory.InitializeAsync();
         var client = factory.CreateAuthenticatedClient();
 
-        await client.PutAsync($"/v1/{factory.TestTenant}/page-versions", CreateJsonContent(new { version = 1 }));
-        await client.PutAsync($"/v1/{factory.TestTenant}/page-versions", CreateJsonContent(new { version = 2 }));
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/page-versions", CreateJsonContent(new { version = 1 }));
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/page-versions", CreateJsonContent(new { version = 2 }));
 
-        var versionsResponse = await client.GetAsync($"/v1/{factory.TestTenant}/page-versions/versions");
+        var versionsResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/page-versions/versions");
         Assert.Equal(HttpStatusCode.OK, versionsResponse.StatusCode);
 
         var versions = await versionsResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -160,7 +160,7 @@ public class ContentApiTests
         Assert.Equal(2, versionEntries[0].GetProperty("version").GetInt32());
         Assert.Equal(1, versionEntries[1].GetProperty("version").GetInt32());
 
-        var versionOne = await client.GetAsync($"/v1/{factory.TestTenant}/page-versions?version=1");
+        var versionOne = await client.GetAsync($"/api/v1/{factory.TestTenant}/page-versions?version=1");
         Assert.Equal(HttpStatusCode.OK, versionOne.StatusCode);
         var data = await versionOne.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal(1, data.GetProperty("version").GetInt32());
@@ -174,11 +174,11 @@ public class ContentApiTests
         var client = factory.CreateAuthenticatedClient();
 
         var wrongContent = new StringContent("plain text", Encoding.UTF8, "text/plain");
-        var wrongResponse = await client.PutAsync($"/v1/{factory.TestTenant}/plain", wrongContent);
+        var wrongResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/plain", wrongContent);
         Assert.Equal(HttpStatusCode.BadRequest, wrongResponse.StatusCode);
 
         var empty = new StringContent(string.Empty, Encoding.UTF8, "application/json");
-        var emptyResponse = await client.PutAsync($"/v1/{factory.TestTenant}/plain", empty);
+        var emptyResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/plain", empty);
         Assert.Equal(HttpStatusCode.BadRequest, emptyResponse.StatusCode);
     }
 
@@ -189,7 +189,7 @@ public class ContentApiTests
         await factory.InitializeAsync();
         var client = factory.CreateAuthenticatedClient();
         var invalidJson = CreateInvalidJsonContent();
-        var invalidResponse = await client.PutAsync($"/v1/{factory.TestTenant}/plain", invalidJson);
+        var invalidResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/plain", invalidJson);
         Assert.Equal(HttpStatusCode.BadRequest, invalidResponse.StatusCode);
     }
 

--- a/CmsLiteTests/ContentDetailsApiTests.cs
+++ b/CmsLiteTests/ContentDetailsApiTests.cs
@@ -23,13 +23,13 @@ public class ContentDetailsApiTests : IAsyncDisposable
 
         // Create content first
         var contentData = JsonSerializer.Serialize(new { message = "Test content for details", timestamp = DateTime.UtcNow });
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/test-resource.json",
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/test-resource.json",
             new StringContent(contentData, System.Text.Encoding.UTF8, "application/json"));
 
         Assert.True(putResponse.StatusCode == HttpStatusCode.OK || putResponse.StatusCode == HttpStatusCode.Created);
 
         // Get detailed information
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/test-resource.json/details");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/test-resource.json/details");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -78,18 +78,18 @@ public class ContentDetailsApiTests : IAsyncDisposable
 
         // Create initial content
         var contentV1 = JsonSerializer.Serialize(new { version = 1, data = "first version" });
-        var putResponse1 = await client.PutAsync($"/v1/{factory.TestTenant}/versioned-resource",
+        var putResponse1 = await client.PutAsync($"/api/v1/{factory.TestTenant}/versioned-resource",
             new StringContent(contentV1, System.Text.Encoding.UTF8, "application/json"));
         Assert.True(putResponse1.StatusCode == HttpStatusCode.OK || putResponse1.StatusCode == HttpStatusCode.Created);
 
         // Update content to create version 2
         var contentV2 = JsonSerializer.Serialize(new { version = 2, data = "second version with more data" });
-        var putResponse2 = await client.PutAsync($"/v1/{factory.TestTenant}/versioned-resource",
+        var putResponse2 = await client.PutAsync($"/api/v1/{factory.TestTenant}/versioned-resource",
             new StringContent(contentV2, System.Text.Encoding.UTF8, "application/json"));
         Assert.True(putResponse2.StatusCode == HttpStatusCode.OK || putResponse2.StatusCode == HttpStatusCode.Created);
 
         // Get detailed information
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/versioned-resource/details");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/versioned-resource/details");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var content = await response.Content.ReadAsStringAsync();
@@ -123,7 +123,7 @@ public class ContentDetailsApiTests : IAsyncDisposable
         var token = factory.GenerateTestJwtToken();
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/nonexistent-resource/details");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/nonexistent-resource/details");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -136,7 +136,7 @@ public class ContentDetailsApiTests : IAsyncDisposable
         var token = factory.GenerateTestJwtToken();
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
-        var response = await client.GetAsync("/v1/invalid-tenant/test-resource/details");
+        var response = await client.GetAsync("/api/v1/invalid-tenant/test-resource/details");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -147,7 +147,7 @@ public class ContentDetailsApiTests : IAsyncDisposable
         await factory.InitializeAsync();
         var client = factory.CreateClient();
 
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/test-resource/details");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/test-resource/details");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -162,16 +162,16 @@ public class ContentDetailsApiTests : IAsyncDisposable
 
         // Create content
         var contentData = JsonSerializer.Serialize(new { message = "Content to be deleted" });
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/deleted-resource",
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/deleted-resource",
             new StringContent(contentData, System.Text.Encoding.UTF8, "application/json"));
         Assert.True(putResponse.StatusCode == HttpStatusCode.OK || putResponse.StatusCode == HttpStatusCode.Created);
 
         // Delete the content
-        var deleteResponse = await client.DeleteAsync($"/v1/{factory.TestTenant}/deleted-resource");
+        var deleteResponse = await client.DeleteAsync($"/api/v1/{factory.TestTenant}/deleted-resource");
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
         // Try to get details of deleted content
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/deleted-resource/details");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/deleted-resource/details");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -205,7 +205,7 @@ public class ContentDetailsApiTests : IAsyncDisposable
 
         // Create content in subdirectory
         var contentData = JsonSerializer.Serialize(new { location = "subdirectory" });
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/v1/{factory.TestTenant}/subdir-resource")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/{factory.TestTenant}/subdir-resource")
         {
             Content = new StringContent(contentData, System.Text.Encoding.UTF8, "application/json")
         };
@@ -215,7 +215,7 @@ public class ContentDetailsApiTests : IAsyncDisposable
         Assert.True(putResponse.StatusCode == HttpStatusCode.OK || putResponse.StatusCode == HttpStatusCode.Created);
 
         // Get details
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/subdir-resource/details");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/subdir-resource/details");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var content = await response.Content.ReadAsStringAsync();

--- a/CmsLiteTests/DirectoryApiTests.cs
+++ b/CmsLiteTests/DirectoryApiTests.cs
@@ -37,7 +37,7 @@ public class DirectoryApiTests
         };
         await directoryRepo.CreateDirectoryAsync(docsDir);
 
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var content = await response.Content.ReadAsStringAsync();
@@ -71,7 +71,7 @@ public class DirectoryApiTests
 
         var rootDir = await directoryRepo.GetOrCreateRootDirectoryAsync(CmsLiteTestFactoryAuth.TestTenantId);
 
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories/{rootDir.Id}");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/{rootDir.Id}");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var content = await response.Content.ReadAsStringAsync();
@@ -92,7 +92,7 @@ public class DirectoryApiTests
         var client = factory.CreateAuthenticatedClient();
 
         var nonExistentId = Guid.NewGuid().ToString();
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories/{nonExistentId}");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/{nonExistentId}");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
@@ -114,7 +114,7 @@ public class DirectoryApiTests
             parentId = rootDir.Id
         };
 
-        var response = await client.PostAsJsonAsync($"/v1/{factory.TestTenant}/directories", createRequest);
+        var response = await client.PostAsJsonAsync($"/api/v1/{factory.TestTenant}/directories", createRequest);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var content = await response.Content.ReadAsStringAsync();
@@ -128,7 +128,7 @@ public class DirectoryApiTests
         // Verify location header
         var location = response.Headers.Location?.ToString();
         Assert.NotNull(location);
-        Assert.Contains($"/v1/{factory.TestTenant}/directories/", location);
+        Assert.Contains($"/api/v1/{factory.TestTenant}/directories/", location);
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class DirectoryApiTests
             // No parentId - should create root-level directory
         };
 
-        var response = await client.PostAsJsonAsync($"/v1/{factory.TestTenant}/directories", createRequest);
+        var response = await client.PostAsJsonAsync($"/api/v1/{factory.TestTenant}/directories", createRequest);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var content = await response.Content.ReadAsStringAsync();
@@ -168,7 +168,7 @@ public class DirectoryApiTests
             parentId = "non-existent-parent-id"
         };
 
-        var response = await client.PostAsJsonAsync($"/v1/{factory.TestTenant}/directories", createRequest);
+        var response = await client.PostAsJsonAsync($"/api/v1/{factory.TestTenant}/directories", createRequest);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
         var errorContent = await response.Content.ReadAsStringAsync();
@@ -213,7 +213,7 @@ public class DirectoryApiTests
             parentId = lastDirectoryId
         };
 
-        var response = await client.PostAsJsonAsync($"/v1/{factory.TestTenant}/directories", createRequest);
+        var response = await client.PostAsJsonAsync($"/api/v1/{factory.TestTenant}/directories", createRequest);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
         var errorContent = await response.Content.ReadAsStringAsync();
@@ -236,12 +236,12 @@ public class DirectoryApiTests
         // Create content in root directory
         var contentPayload = new { title = "Test Content" };
         var contentRequest = JsonSerializer.Serialize(contentPayload);
-        var createContentResponse = await client.PutAsync($"/v1/{factory.TestTenant}/test-content",
+        var createContentResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/test-content",
             new StringContent(contentRequest, Encoding.UTF8, "application/json"));
         Assert.Equal(HttpStatusCode.Created, createContentResponse.StatusCode);
 
         // Get directory contents
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories/{rootDir.Id}/contents");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/{rootDir.Id}/contents");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var content = await response.Content.ReadAsStringAsync();
@@ -287,14 +287,14 @@ public class DirectoryApiTests
         // Create content in root directory
         var rootContentPayload = new { title = "Root Content" };
         var rootContentRequest = JsonSerializer.Serialize(rootContentPayload);
-        var rootContentResponse = await client.PutAsync($"/v1/{factory.TestTenant}/root-content",
+        var rootContentResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/root-content",
             new StringContent(rootContentRequest, Encoding.UTF8, "application/json"));
         Assert.Equal(HttpStatusCode.Created, rootContentResponse.StatusCode);
 
         // Create content in Documents directory
         var docsContentPayload = new { title = "Doc Content" };
         var docsContentRequest = JsonSerializer.Serialize(docsContentPayload);
-        var docsRequest = new HttpRequestMessage(HttpMethod.Put, $"/v1/{factory.TestTenant}/doc-content")
+        var docsRequest = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/{factory.TestTenant}/doc-content")
         {
             Content = new StringContent(docsContentRequest, Encoding.UTF8, "application/json")
         };
@@ -303,7 +303,7 @@ public class DirectoryApiTests
         Assert.Equal(HttpStatusCode.Created, docsContentResponse.StatusCode);
 
         // Get directory tree and verify content counts
-        var treeResponse = await client.GetAsync($"/v1/{factory.TestTenant}/directories");
+        var treeResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories");
         Assert.Equal(HttpStatusCode.OK, treeResponse.StatusCode);
 
         var treeContent = await treeResponse.Content.ReadAsStringAsync();
@@ -322,7 +322,7 @@ public class DirectoryApiTests
         Assert.Equal(1, docsDirResponse.GetProperty("contentCount").GetInt32());
 
         // Also test specific directory endpoint for root
-        var rootDetailsResponse = await client.GetAsync($"/v1/{factory.TestTenant}/directories/{rootDir.Id}");
+        var rootDetailsResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/{rootDir.Id}");
         Assert.Equal(HttpStatusCode.OK, rootDetailsResponse.StatusCode);
 
         var rootDetailsContent = await rootDetailsResponse.Content.ReadAsStringAsync();
@@ -330,7 +330,7 @@ public class DirectoryApiTests
         Assert.Equal(1, rootDetailsResult.GetProperty("contentCount").GetInt32());
 
         // Also test specific directory endpoint for Documents
-        var docsDetailsResponse = await client.GetAsync($"/v1/{factory.TestTenant}/directories/{docsDir.Id}");
+        var docsDetailsResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/{docsDir.Id}");
         Assert.Equal(HttpStatusCode.OK, docsDetailsResponse.StatusCode);
 
         var docsDetailsContent = await docsDetailsResponse.Content.ReadAsStringAsync();
@@ -347,10 +347,10 @@ public class DirectoryApiTests
 
         // Test all endpoints require authentication
         var responses = await Task.WhenAll(
-            client.GetAsync($"/v1/{factory.TestTenant}/directories"),
-            client.GetAsync($"/v1/{factory.TestTenant}/directories/{Guid.NewGuid()}"),
-            client.PostAsJsonAsync($"/v1/{factory.TestTenant}/directories", new { name = "Test" }),
-            client.GetAsync($"/v1/{factory.TestTenant}/directories/{Guid.NewGuid()}/contents")
+            client.GetAsync($"/api/v1/{factory.TestTenant}/directories"),
+            client.GetAsync($"/api/v1/{factory.TestTenant}/directories/{Guid.NewGuid()}"),
+            client.PostAsJsonAsync($"/api/v1/{factory.TestTenant}/directories", new { name = "Test" }),
+            client.GetAsync($"/api/v1/{factory.TestTenant}/directories/{Guid.NewGuid()}/contents")
         );
 
         // All should return 401 Unauthorized
@@ -367,7 +367,7 @@ public class DirectoryApiTests
         await factory.InitializeAsync();
         var client = factory.CreateAuthenticatedClient();
 
-        var response = await client.GetAsync("/v1/nonexistent-tenant/directories");
+        var response = await client.GetAsync("/api/v1/nonexistent-tenant/directories");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }

--- a/CmsLiteTests/DirectoryTreeApiTests.cs
+++ b/CmsLiteTests/DirectoryTreeApiTests.cs
@@ -33,7 +33,7 @@ public class DirectoryTreeApiTests : IAsyncDisposable
         var token = factory.GenerateTestJwtToken();
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories/tree");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/tree");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -63,13 +63,13 @@ public class DirectoryTreeApiTests : IAsyncDisposable
 
         // Add some content items via API
         var contentData = JsonSerializer.Serialize(new { message = "Test content", data = new { value = 123 } });
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/test-resource",
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/test-resource",
             new StringContent(contentData, System.Text.Encoding.UTF8, "application/json"));
 
         Assert.True(putResponse.StatusCode == HttpStatusCode.OK || putResponse.StatusCode == HttpStatusCode.Created);
 
         // Get the directory tree
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories/tree");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/tree");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -101,7 +101,7 @@ public class DirectoryTreeApiTests : IAsyncDisposable
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
         // Get root directory ID first
-        var rootDirResponse = await client.GetAsync($"/v1/{factory.TestTenant}/directories");
+        var rootDirResponse = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories");
         Assert.Equal(HttpStatusCode.OK, rootDirResponse.StatusCode);
 
         var rootDirContent = await rootDirResponse.Content.ReadAsStringAsync();
@@ -117,11 +117,11 @@ public class DirectoryTreeApiTests : IAsyncDisposable
         // Create a subdirectory
         var createDirRequest = new CreateDirectoryRequest("SubDir1", rootDirId);
 
-        var createResponse = await client.PostAsJsonAsync($"/v1/{factory.TestTenant}/directories", createDirRequest);
+        var createResponse = await client.PostAsJsonAsync($"/api/v1/{factory.TestTenant}/directories", createDirRequest);
         Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
 
         // Get the directory tree
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories/tree");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/tree");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -151,7 +151,7 @@ public class DirectoryTreeApiTests : IAsyncDisposable
 
         // Don't create root directory - should return empty tree
 
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories/tree");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/tree");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -178,7 +178,7 @@ public class DirectoryTreeApiTests : IAsyncDisposable
         var token = factory.GenerateTestJwtToken();
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
-        var response = await client.GetAsync("/v1/nonexistent-tenant/directories/tree");
+        var response = await client.GetAsync("/api/v1/nonexistent-tenant/directories/tree");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -189,7 +189,7 @@ public class DirectoryTreeApiTests : IAsyncDisposable
         await factory.InitializeAsync();
         var client = factory.CreateClient();
 
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories/tree");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/tree");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -206,16 +206,16 @@ public class DirectoryTreeApiTests : IAsyncDisposable
 
         // Create content
         var contentData = JsonSerializer.Serialize(new { message = "Test content" });
-        var putResponse = await client.PutAsync($"/v1/{factory.TestTenant}/test-resource",
+        var putResponse = await client.PutAsync($"/api/v1/{factory.TestTenant}/test-resource",
             new StringContent(contentData, System.Text.Encoding.UTF8, "application/json"));
         Assert.True(putResponse.StatusCode == HttpStatusCode.OK || putResponse.StatusCode == HttpStatusCode.Created);
 
         // Delete the content
-        var deleteResponse = await client.DeleteAsync($"/v1/{factory.TestTenant}/test-resource");
+        var deleteResponse = await client.DeleteAsync($"/api/v1/{factory.TestTenant}/test-resource");
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
         // Get the directory tree
-        var response = await client.GetAsync($"/v1/{factory.TestTenant}/directories/tree");
+        var response = await client.GetAsync($"/api/v1/{factory.TestTenant}/directories/tree");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 

--- a/CmsLiteTests/RateLimitingTests.cs
+++ b/CmsLiteTests/RateLimitingTests.cs
@@ -29,7 +29,7 @@ public class RateLimitingTests : IAsyncDisposable
             };
             var requestJson = JsonSerializer.Serialize(request);
 
-            tasks.Add(client.PostAsync("/auth/login", new StringContent(requestJson, Encoding.UTF8, "application/json")));
+            tasks.Add(client.PostAsync("/api/auth/login", new StringContent(requestJson, Encoding.UTF8, "application/json")));
         }
 
         var responses = await Task.WhenAll(tasks);
@@ -56,13 +56,13 @@ public class RateLimitingTests : IAsyncDisposable
         // Create some content first
         var content = new { title = "Test Content" };
         var contentJson = JsonSerializer.Serialize(content);
-        await client.PutAsync($"/v1/{factory.TestTenant}/test-content", new StringContent(contentJson, Encoding.UTF8, "application/json"));
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/test-content", new StringContent(contentJson, Encoding.UTF8, "application/json"));
 
         // Make many requests to the content read endpoint
         var tasks = new List<Task<HttpResponseMessage>>();
         for (int i = 0; i < 15; i++) // Reduced for faster test execution
         {
-            tasks.Add(client.GetAsync($"/v1/{factory.TestTenant}/test-content"));
+            tasks.Add(client.GetAsync($"/api/v1/{factory.TestTenant}/test-content"));
         }
 
         var responses = await Task.WhenAll(tasks);
@@ -84,7 +84,7 @@ public class RateLimitingTests : IAsyncDisposable
         {
             var content = new { title = $"Test Content {i}" };
             var contentJson = JsonSerializer.Serialize(content);
-            tasks.Add(client.PutAsync($"/v1/{factory.TestTenant}/test-content-{i}", new StringContent(contentJson, Encoding.UTF8, "application/json")));
+            tasks.Add(client.PutAsync($"/api/v1/{factory.TestTenant}/test-content-{i}", new StringContent(contentJson, Encoding.UTF8, "application/json")));
         }
 
         var responses = await Task.WhenAll(tasks);
@@ -103,7 +103,7 @@ public class RateLimitingTests : IAsyncDisposable
         // Create content to delete
         var content = new { title = "Test Content for Bulk Delete" };
         var contentJson = JsonSerializer.Serialize(content);
-        await client.PutAsync($"/v1/{factory.TestTenant}/bulk-test", new StringContent(contentJson, Encoding.UTF8, "application/json"));
+        await client.PutAsync($"/api/v1/{factory.TestTenant}/bulk-test", new StringContent(contentJson, Encoding.UTF8, "application/json"));
 
         // Make many bulk delete requests
         var tasks = new List<Task<HttpResponseMessage>>();
@@ -111,7 +111,7 @@ public class RateLimitingTests : IAsyncDisposable
         {
             var deleteRequest = new { Resources = new[] { "bulk-test" } };
             var deleteRequestJson = JsonSerializer.Serialize(deleteRequest);
-            var request = new HttpRequestMessage(HttpMethod.Delete, $"/v1/{factory.TestTenant}/bulk-delete")
+            var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/{factory.TestTenant}/bulk-delete")
             {
                 Content = new StringContent(deleteRequestJson, Encoding.UTF8, "application/json")
             };
@@ -137,7 +137,7 @@ public class RateLimitingTests : IAsyncDisposable
         {
             var request = new { Email = "test@test.com", Password = "wrongpassword" };
             var requestJson = JsonSerializer.Serialize(request);
-            var response = await client.PostAsync("/auth/login", new StringContent(requestJson, Encoding.UTF8, "application/json"));
+            var response = await client.PostAsync("/api/auth/login", new StringContent(requestJson, Encoding.UTF8, "application/json"));
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {

--- a/CmsLiteTests/TenantIsolationTests.cs
+++ b/CmsLiteTests/TenantIsolationTests.cs
@@ -25,7 +25,7 @@ public class TenantIsolationTests : IAsyncDisposable
         var tenantAClient = factory.CreateAuthenticatedClient();
 
         // Try to access Tenant B's directories - should be forbidden
-        var response = await tenantAClient.GetAsync("/v1/tenant-b/directories/tree");
+        var response = await tenantAClient.GetAsync("/api/v1/tenant-b/directories/tree");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
 
@@ -42,7 +42,7 @@ public class TenantIsolationTests : IAsyncDisposable
         var tenantAClient = factory.CreateAuthenticatedClient();
 
         // Try to access Tenant B's content - should be forbidden
-        var response = await tenantAClient.GetAsync("/v1/tenant-b/some-resource");
+        var response = await tenantAClient.GetAsync("/api/v1/tenant-b/some-resource");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
 
@@ -60,7 +60,7 @@ public class TenantIsolationTests : IAsyncDisposable
 
         // Try to create content in Tenant B - should be forbidden
         var contentJson = JsonSerializer.Serialize(new { title = "Malicious Content" });
-        var response = await tenantAClient.PutAsync("/v1/tenant-b/malicious-resource",
+        var response = await tenantAClient.PutAsync("/api/v1/tenant-b/malicious-resource",
             new StringContent(contentJson, Encoding.UTF8, "application/json"));
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -78,7 +78,7 @@ public class TenantIsolationTests : IAsyncDisposable
         var tenantAClient = factory.CreateAuthenticatedClient();
 
         // Try to delete content in Tenant B - should be forbidden
-        var response = await tenantAClient.DeleteAsync("/v1/tenant-b/some-resource");
+        var response = await tenantAClient.DeleteAsync("/api/v1/tenant-b/some-resource");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
 
@@ -97,7 +97,7 @@ public class TenantIsolationTests : IAsyncDisposable
         // Try to bulk delete content in Tenant B - should be forbidden
         var deleteRequest = new { resources = new[] { "resource1", "resource2" } };
         var deleteRequestJson = JsonSerializer.Serialize(deleteRequest);
-        var request = new HttpRequestMessage(HttpMethod.Delete, "/v1/tenant-b/bulk-delete")
+        var request = new HttpRequestMessage(HttpMethod.Delete, "/api/v1/tenant-b/bulk-delete")
         {
             Content = new StringContent(deleteRequestJson, Encoding.UTF8, "application/json")
         };
@@ -118,7 +118,7 @@ public class TenantIsolationTests : IAsyncDisposable
         var tenantAClient = factory.CreateAuthenticatedClient();
 
         // User should be able to access their own tenant's directories
-        var response = await tenantAClient.GetAsync("/v1/acme/directories/tree");
+        var response = await tenantAClient.GetAsync("/api/v1/acme/directories/tree");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -139,7 +139,7 @@ public class TenantIsolationTests : IAsyncDisposable
             new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", tenantBToken);
 
         // Try to access Tenant A's directories - should be forbidden
-        var response = await tenantBClient.GetAsync("/v1/acme/directories/tree");
+        var response = await tenantBClient.GetAsync("/api/v1/acme/directories/tree");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
 
@@ -155,7 +155,7 @@ public class TenantIsolationTests : IAsyncDisposable
         var client = factory.CreateAuthenticatedClient();
 
         // Try to access an endpoint with an invalid tenant format (missing resource)
-        var response = await client.GetAsync("/v1/invalid");
+        var response = await client.GetAsync("/api/v1/invalid");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
@@ -173,7 +173,7 @@ public class TenantIsolationTests : IAsyncDisposable
 
         // Unauthenticated requests should pass through the middleware
         // (will be handled by authentication middleware later)
-        var response = await client.GetAsync("/v1/acme/directories/tree");
+        var response = await client.GetAsync("/api/v1/acme/directories/tree");
 
         // Should return 401 Unauthorized (from authentication middleware), not 403 Forbidden
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -201,7 +201,7 @@ public class TenantIsolationTests : IAsyncDisposable
         var tenantAClient = factory.CreateAuthenticatedClient();
 
         // This should trigger a security log entry
-        var response = await tenantAClient.GetAsync("/v1/tenant-b/directories/tree");
+        var response = await tenantAClient.GetAsync("/api/v1/tenant-b/directories/tree");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Password: abc
 ### API Authentication
 ```bash
 # Login
-curl -X POST http://localhost:8080/auth/login \
+curl -X POST http://localhost:8080/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email": "admin@email.com", "password": "abc"}'
 
@@ -84,11 +84,11 @@ curl -X POST http://localhost:8080/auth/login \
 }
 
 # Use token for authenticated requests
-curl -X GET http://localhost:8080/v1/acme/config \
+curl -X GET http://localhost:8080/api/v1/acme/config \
   -H "Authorization: Bearer YOUR_JWT_TOKEN"
 
 # Refresh token (with rotation)
-curl -X POST http://localhost:8080/auth/refresh \
+curl -X POST http://localhost:8080/api/auth/refresh \
   -H "Content-Type: application/json" \
   -d '{"token": "YOUR_CURRENT_TOKEN"}'
 ```
@@ -98,35 +98,35 @@ curl -X POST http://localhost:8080/auth/refresh \
 ## 📡 API Endpoints
 
 ### 🔐 Authentication (Public)
-- **POST /auth/login** → User authentication with email/password
-- **POST /auth/logout** → Revoke current session
-- **GET /auth/me** → Get current user information
-- **POST /auth/refresh** → Refresh authentication token (with rotation)
+- **POST /api/auth/login** → User authentication with email/password
+- **POST /api/auth/logout** → Revoke current session
+- **GET /api/auth/me** → Get current user information
+- **POST /api/auth/refresh** → Refresh authentication token (with rotation)
 
 ### 👥 User & Tenant Management (Public)
-- **POST /create-tenant** → Create new tenant with owner user
+- **POST /api/create-tenant** → Create new tenant with owner user
 
 ### 👥 User & Tenant Management (Authenticated)
-- **POST /attach-user** → Attach user to existing tenant
+- **POST /api/attach-user** → Attach user to existing tenant
 
 ### 📁 Content Management (Authenticated)
-- **PUT /v1/{tenant}/{resource}** → Create/update JSON or XML content (auto-versioned)
+- **PUT /api/v1/{tenant}/{resource}** → Create/update JSON or XML content (auto-versioned)
   - *Required header*: `Content-Type: application/json`, `application/xml`, or `text/xml`
   - *Optional header*: `X-Directory-Id: {directoryId}` (if not provided, uses root directory)
-- **GET /v1/{tenant}/{resource}** → Retrieve content (latest or specific version)
-- **HEAD /v1/{tenant}/{resource}** → Get metadata without content body
-- **DELETE /v1/{tenant}/{resource}** → Soft delete single content resource
-- **DELETE /v1/{tenant}/bulk-delete** → **Bulk soft delete multiple content resources** (atomic transaction)
-- **GET /v1/{tenant}** → List tenant resources (with filtering/pagination)
-- **GET /v1/{tenant}/{resource}/versions** → List all versions of resource
-- **GET /v1/{tenant}/{resource}/details** → Get comprehensive resource details with version history and directory info
+- **GET /api/v1/{tenant}/{resource}** → Retrieve content (latest or specific version)
+- **HEAD /api/v1/{tenant}/{resource}** → Get metadata without content body
+- **DELETE /api/v1/{tenant}/{resource}** → Soft delete single content resource
+- **DELETE /api/v1/{tenant}/bulk-delete** → **Bulk soft delete multiple content resources** (atomic transaction)
+- **GET /api/v1/{tenant}** → List tenant resources (with filtering/pagination)
+- **GET /api/v1/{tenant}/{resource}/versions** → List all versions of resource
+- **GET /api/v1/{tenant}/{resource}/details** → Get comprehensive resource details with version history and directory info
 
 ### 📂 Directory Management (Authenticated)
-- **GET /v1/{tenant}/directories** → List directory tree for tenant
-- **GET /v1/{tenant}/directories/tree** → Get complete directory tree with all content items in single response
-- **POST /v1/{tenant}/directories** → Create new directory with optional parent
-- **GET /v1/{tenant}/directories/{id}** → Get directory details and metadata
-- **GET /v1/{tenant}/directories/{id}/contents** → Get content items in directory
+- **GET /api/v1/{tenant}/directories** → List directory tree for tenant
+- **GET /api/v1/{tenant}/directories/tree** → Get complete directory tree with all content items in single response
+- **POST /api/v1/{tenant}/directories** → Create new directory with optional parent
+- **GET /api/v1/{tenant}/directories/{id}** → Get directory details and metadata
+- **GET /api/v1/{tenant}/directories/{id}/contents** → Get content items in directory
 
 **Features:**
 - **Hierarchical Structure**: Support for up to 5 nesting levels (0-4)
@@ -195,9 +195,9 @@ All content endpoints require **Bearer token authentication** and enforce **tena
 
 #### 1. **Authentication Flow**
 
-**Login** (POST /auth/login):
+**Login** (POST /api/auth/login):
 ```bash
-POST http://localhost:8080/auth/login
+POST http://localhost:8080/api/auth/login
 Content-Type: application/json
 
 {
@@ -222,17 +222,17 @@ Content-Type: application/json
 }
 ```
 
-**Get Current User** (GET /auth/me):
+**Get Current User** (GET /api/auth/me):
 ```bash
-GET http://localhost:8080/auth/me
+GET http://localhost:8080/api/auth/me
 Authorization: Bearer {your-jwt-token}
 ```
 
 #### 2. **Content Management with Directory Support**
 
-**Create Content in Root Directory** (PUT /v1/{tenant}/{resource}):
+**Create Content in Root Directory** (PUT /api/v1/{tenant}/{resource}):
 ```bash
-PUT http://localhost:8080/v1/acme/config
+PUT http://localhost:8080/api/v1/acme/config
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 
@@ -256,9 +256,9 @@ Content-Type: application/json
 }
 ```
 
-**Create Content in Specific Directory** (PUT /v1/{tenant}/{resource}):
+**Create Content in Specific Directory** (PUT /api/v1/{tenant}/{resource}):
 ```bash
-PUT http://localhost:8080/v1/acme/homepage
+PUT http://localhost:8080/api/v1/acme/homepage
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 X-Directory-Id: {directory-id-from-your-setup}
@@ -270,9 +270,9 @@ X-Directory-Id: {directory-id-from-your-setup}
 }
 ```
 
-**Create XML Content** (PUT /v1/{tenant}/{resource}):
+**Create XML Content** (PUT /api/v1/{tenant}/{resource}):
 ```bash
-PUT http://localhost:8080/v1/acme/settings.xml
+PUT http://localhost:8080/api/v1/acme/settings.xml
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/xml
 
@@ -300,29 +300,29 @@ Content-Type: application/xml
 }
 ```
 
-**Retrieve Content** (GET /v1/{tenant}/{resource}):
+**Retrieve Content** (GET /api/v1/{tenant}/{resource}):
 ```bash
-GET http://localhost:8080/v1/acme/config
+GET http://localhost:8080/api/v1/acme/config
 Authorization: Bearer {your-jwt-token}
 
 # Response includes content + ETag header
 ```
 
-**Get Content Metadata** (HEAD /v1/{tenant}/{resource}):
+**Get Content Metadata** (HEAD /api/v1/{tenant}/{resource}):
 ```bash
-HEAD http://localhost:8080/v1/acme/config
+HEAD http://localhost:8080/api/v1/acme/config
 Authorization: Bearer {your-jwt-token}
 
 # Response: Headers only (ETag, Content-Length, Content-Type)
 ```
 
-**List Tenant Resources** (GET /v1/{tenant}):
+**List Tenant Resources** (GET /api/v1/{tenant}):
 ```bash
-GET http://localhost:8080/v1/acme
+GET http://localhost:8080/api/v1/acme
 Authorization: Bearer {your-jwt-token}
 
 # With filtering:
-GET http://localhost:8080/v1/acme?prefix=home&limit=10
+GET http://localhost:8080/api/v1/acme?prefix=home&limit=10
 
 # Response:
 {
@@ -342,9 +342,9 @@ GET http://localhost:8080/v1/acme?prefix=home&limit=10
 }
 ```
 
-**Update Content with Optimistic Concurrency** (PUT /v1/{tenant}/{resource}):
+**Update Content with Optimistic Concurrency** (PUT /api/v1/{tenant}/{resource}):
 ```bash
-PUT http://localhost:8080/v1/acme/config
+PUT http://localhost:8080/api/v1/acme/config
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 If-Match: {etag-from-previous-response}
@@ -355,9 +355,9 @@ If-Match: {etag-from-previous-response}
 }
 ```
 
-**Get Content Versions** (GET /v1/{tenant}/{resource}/versions):
+**Get Content Versions** (GET /api/v1/{tenant}/{resource}/versions):
 ```bash
-GET http://localhost:8080/v1/acme/config/versions
+GET http://localhost:8080/api/v1/acme/config/versions
 Authorization: Bearer {your-jwt-token}
 
 # Response:
@@ -379,23 +379,23 @@ Authorization: Bearer {your-jwt-token}
 ]
 ```
 
-**Get Specific Version** (GET /v1/{tenant}/{resource}?version={version}):
+**Get Specific Version** (GET /api/v1/{tenant}/{resource}?version={version}):
 ```bash
-GET http://localhost:8080/v1/acme/config?version=1
+GET http://localhost:8080/api/v1/acme/config?version=1
 Authorization: Bearer {your-jwt-token}
 ```
 
-**Soft Delete Single Content** (DELETE /v1/{tenant}/{resource}):
+**Soft Delete Single Content** (DELETE /api/v1/{tenant}/{resource}):
 ```bash
-DELETE http://localhost:8080/v1/acme/config
+DELETE http://localhost:8080/api/v1/acme/config
 Authorization: Bearer {your-jwt-token}
 
 # Response: 204 No Content
 ```
 
-**Bulk Soft Delete Content** (DELETE /v1/{tenant}/bulk-delete):
+**Bulk Soft Delete Content** (DELETE /api/v1/{tenant}/bulk-delete):
 ```bash
-DELETE http://localhost:8080/v1/acme/bulk-delete
+DELETE http://localhost:8080/api/v1/acme/bulk-delete
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 
@@ -447,9 +447,9 @@ Content-Type: application/json
 
 #### 3. **Directory Management Examples**
 
-**List Directory Tree** (GET /v1/{tenant}/directories):
+**List Directory Tree** (GET /api/v1/{tenant}/directories):
 ```bash
-GET http://localhost:8080/v1/acme/directories
+GET http://localhost:8080/api/v1/acme/directories
 Authorization: Bearer {your-jwt-token}
 
 # Response:
@@ -478,9 +478,9 @@ Authorization: Bearer {your-jwt-token}
 }
 ```
 
-**Create New Directory** (POST /v1/{tenant}/directories):
+**Create New Directory** (POST /api/v1/{tenant}/directories):
 ```bash
-POST http://localhost:8080/v1/acme/directories
+POST http://localhost:8080/api/v1/acme/directories
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 
@@ -500,9 +500,9 @@ Content-Type: application/json
 }
 ```
 
-**Get Directory Details** (GET /v1/{tenant}/directories/{id}):
+**Get Directory Details** (GET /api/v1/{tenant}/directories/{id}):
 ```bash
-GET http://localhost:8080/v1/acme/directories/docs-dir-id
+GET http://localhost:8080/api/v1/acme/directories/docs-dir-id
 Authorization: Bearer {your-jwt-token}
 
 # Response:
@@ -521,9 +521,9 @@ Authorization: Bearer {your-jwt-token}
 ```
 
 
-**Get Directory Contents** (GET /v1/{tenant}/directories/{id}/contents):
+**Get Directory Contents** (GET /api/v1/{tenant}/directories/{id}/contents):
 ```bash
-GET http://localhost:8080/v1/acme/directories/docs-dir-id/contents
+GET http://localhost:8080/api/v1/acme/directories/docs-dir-id/contents
 Authorization: Bearer {your-jwt-token}
 
 # Response:
@@ -552,9 +552,9 @@ Authorization: Bearer {your-jwt-token}
 }
 ```
 
-**Get Complete Directory Tree** (GET /v1/{tenant}/directories/tree):
+**Get Complete Directory Tree** (GET /api/v1/{tenant}/directories/tree):
 ```bash
-GET http://localhost:8080/v1/acme/directories/tree
+GET http://localhost:8080/api/v1/acme/directories/tree
 Authorization: Bearer {your-jwt-token}
 
 # Response:
@@ -595,9 +595,9 @@ Authorization: Bearer {your-jwt-token}
 }
 ```
 
-**Get Content Details** (GET /v1/{tenant}/{resource}/details):
+**Get Content Details** (GET /api/v1/{tenant}/{resource}/details):
 ```bash
-GET http://localhost:8080/v1/acme/config/details
+GET http://localhost:8080/api/v1/acme/config/details
 Authorization: Bearer {your-jwt-token}
 
 # Response:
@@ -647,7 +647,7 @@ Authorization: Bearer {your-jwt-token}
 
 **Test Invalid Directory ID**:
 ```bash
-PUT http://localhost:8080/v1/acme/test-content
+PUT http://localhost:8080/api/v1/acme/test-content
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 X-Directory-Id: invalid-directory-id
@@ -662,7 +662,7 @@ X-Directory-Id: invalid-directory-id
 
 **Test Cross-Tenant Directory Access**:
 ```bash
-PUT http://localhost:8080/v1/acme/test-content
+PUT http://localhost:8080/api/v1/acme/test-content
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 X-Directory-Id: {directory-id-from-different-tenant}
@@ -679,7 +679,7 @@ X-Directory-Id: {directory-id-from-different-tenant}
 **Test Directory Nesting Limit**:
 ```bash
 # After creating 5 levels (0,1,2,3,4), attempt to create 6th level
-POST http://localhost:8080/v1/acme/directories
+POST http://localhost:8080/api/v1/acme/directories
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 
@@ -696,7 +696,7 @@ Content-Type: application/json
 
 **Unauthorized Request**:
 ```bash
-GET http://localhost:8080/v1/acme/config
+GET http://localhost:8080/api/v1/acme/config
 # No Authorization header
 
 # Expected: 401 Unauthorized
@@ -704,7 +704,7 @@ GET http://localhost:8080/v1/acme/config
 
 **Invalid Tenant**:
 ```bash
-GET http://localhost:8080/v1/nonexistent-tenant/config
+GET http://localhost:8080/api/v1/nonexistent-tenant/config
 Authorization: Bearer {your-jwt-token}
 
 # Expected: 400 Bad Request
@@ -713,7 +713,7 @@ Authorization: Bearer {your-jwt-token}
 
 **Optimistic Concurrency Conflict**:
 ```bash
-PUT http://localhost:8080/v1/acme/config
+PUT http://localhost:8080/api/v1/acme/config
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 If-Match: wrong-etag
@@ -729,7 +729,7 @@ If-Match: wrong-etag
 
 **Cross-Directory Bulk Delete** (Resources in different directories):
 ```bash
-DELETE http://localhost:8080/v1/acme/bulk-delete
+DELETE http://localhost:8080/api/v1/acme/bulk-delete
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 
@@ -747,7 +747,7 @@ Content-Type: application/json
 
 **Non-existent Resources**:
 ```bash
-DELETE http://localhost:8080/v1/acme/bulk-delete
+DELETE http://localhost:8080/api/v1/acme/bulk-delete
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 
@@ -766,7 +766,7 @@ Content-Type: application/json
 
 **Empty Resources List**:
 ```bash
-DELETE http://localhost:8080/v1/acme/bulk-delete
+DELETE http://localhost:8080/api/v1/acme/bulk-delete
 Authorization: Bearer {your-jwt-token}
 Content-Type: application/json
 
@@ -784,18 +784,18 @@ Content-Type: application/json
 
 #### 6. **Logout & Token Management**
 
-**Logout** (POST /auth/logout):
+**Logout** (POST /api/auth/logout):
 ```bash
-POST http://localhost:8080/auth/logout
+POST http://localhost:8080/api/auth/logout
 Authorization: Bearer {your-jwt-token}
 
 # Response: 200 OK
 # Token is now invalidated
 ```
 
-**Refresh Token** (POST /auth/refresh):
+**Refresh Token** (POST /api/auth/refresh):
 ```bash
-POST http://localhost:8080/auth/refresh
+POST http://localhost:8080/api/auth/refresh
 Content-Type: application/json
 
 {
@@ -1036,11 +1036,11 @@ CMS-Lite includes built-in rate limiting to protect against abuse and ensure fai
 
 | Policy | Endpoints | Production Limit | Development Limit | Window | Purpose |
 |--------|-----------|------------------|-------------------|--------|---------|
-| **auth** | `/auth/*` | 10 req/min | 50 req/min | 1 minute | Login, logout, token refresh |
-| **content-read** | `GET /v1/{tenant}/*` | 100 req/min | 500 req/min | 1 minute | Content retrieval operations |
-| **content-write** | `PUT /v1/{tenant}/*` | 50 req/min | 200 req/min | 1 minute | Content creation/updates |
-| **bulk-operations** | `DELETE /v1/{tenant}/bulk-*` | 10 req/min | 50 req/min | 1 minute | Bulk delete operations |
-| **admin** | `/create-tenant`, `/attach-user` | 20 req/min | 50 req/min | 1 minute | Administrative operations |
+| **auth** | `/api/auth/*` | 10 req/min | 50 req/min | 1 minute | Login, logout, token refresh |
+| **content-read** | `GET /api/v1/{tenant}/*` | 100 req/min | 500 req/min | 1 minute | Content retrieval operations |
+| **content-write** | `PUT /api/v1/{tenant}/*` | 50 req/min | 200 req/min | 1 minute | Content creation/updates |
+| **bulk-operations** | `DELETE /api/v1/{tenant}/bulk-*` | 10 req/min | 50 req/min | 1 minute | Bulk delete operations |
+| **admin** | `/api/create-tenant`, `/api/attach-user` | 20 req/min | 50 req/min | 1 minute | Administrative operations |
 
 ### Rate Limiting Features
 
@@ -1173,7 +1173,7 @@ CMS-Lite includes comprehensive API documentation via Swagger UI with full JWT a
 
 1. **Access Swagger UI** at `/swagger` in development mode
 2. **Authenticate via API**:
-   - Use the `/auth/login` endpoint with demo credentials (`admin@email.com` / `abc`)
+   - Use the `/api/auth/login` endpoint with demo credentials (`admin@email.com` / `abc`)
    - Copy the JWT token from the response
 3. **Authorize in Swagger**:
    - Click the "Authorize" button in Swagger UI
@@ -1181,7 +1181,7 @@ CMS-Lite includes comprehensive API documentation via Swagger UI with full JWT a
    - Click "Authorize"
 4. **Test Protected Endpoints**:
    - All authenticated endpoints will now include the JWT token automatically
-   - Try endpoints like `/v1/{tenant}/directories` or `/v1/{tenant}/{resource}`
+   - Try endpoints like `/api/v1/{tenant}/directories` or `/api/v1/{tenant}/{resource}`
 
 ### Swagger Features
 

--- a/cms-lite-web-client/src/utilities/custom-axios.ts
+++ b/cms-lite-web-client/src/utilities/custom-axios.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { AxiosInstance } from "axios";
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8080";
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8080/api";
 const customAxios: AxiosInstance = axios.create({ baseURL: API_BASE_URL });
 
 customAxios.interceptors.request.use(


### PR DESCRIPTION
This commit introduces the `/api` prefix to all backend and frontend API endpoints.

Backend changes:
- Modified `CmsLite/Program.cs` to create a new route group with the `/api` prefix.
- Updated `MapAuthenticationEndpoints`, `MapContentEndpoints`, and `MapDirectoryEndpoints` to be compatible with the new route group.

Frontend changes:
- Updated the `API_BASE_URL` in `cms-lite-web-client/src/utilities/custom-axios.ts` to include the `/api` prefix.

Test changes:
- Updated all relevant unit tests in the `CmsLiteTests` project to use the new `/api` prefix in the endpoint URLs.

Documentation changes:
- Updated `README.md` to reflect the new `/api` prefix in the API endpoint documentation.

I was unable to run the tests to verify these changes because the `dotnet` command is not available in the environment, and the `docker compose` command failed to execute.